### PR TITLE
feat: add promise setup support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,8 @@ module.exports = {
 
 ### 2. Create `jest-dynamodb-config.js`
 
-See [Create Table API](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property)
+See [Create Table API](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property)  
+You can set the table as an object:
 
 ```js
 module.exports = {
@@ -36,6 +37,25 @@ module.exports = {
   port: 8000
 };
 ```
+
+Or a function (particularly useful when resolving DynamoDB setup from Serverless or other `async` method):
+
+```js
+module.exports = async () => {
+  await serverless.init();
+  const service = await serverless.variables.populateService();
+  const tables = service.resources.Resources.filter(r => r.Type === 'AWS::DynamoDB::Table').map(
+    r => r.Properties
+  );
+
+  return {
+    tables,
+    port: 8000
+  };
+};
+```
+
+This is prticularly useful
 
 ### 3. Configure DynamoDB client
 

--- a/readme.md
+++ b/readme.md
@@ -20,8 +20,9 @@ module.exports = {
 
 ### 2. Create `jest-dynamodb-config.js`
 
-See [Create Table API](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property)  
-You can set the table as an object:
+See [Create Table API](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property).
+
+You can set up tables as an object:
 
 ```js
 module.exports = {
@@ -38,7 +39,7 @@ module.exports = {
 };
 ```
 
-Or a function (particularly useful when resolving DynamoDB setup from Serverless or other `async` method):
+Or as an async function (particularly useful when resolving DynamoDB setup dynamically from `serverless.yml`):
 
 ```js
 module.exports = async () => {
@@ -54,8 +55,6 @@ module.exports = async () => {
   };
 };
 ```
-
-This is prticularly useful
 
 ### 3. Configure DynamoDB client
 

--- a/setup.js
+++ b/setup.js
@@ -25,7 +25,8 @@ module.exports = async function() {
 };
 
 async function createTables() {
-  const {tables} = require(resolve(cwd(), 'jest-dynamodb-config.js'));
+  const config = require(resolve(cwd(), 'jest-dynamodb-config.js'));
+  const {tables} = typeof config === 'function' ? await config() : config;
 
   return Promise.all(tables.map(table => dynamoDB.createTable(table).promise()));
 }


### PR DESCRIPTION
Adding the ability to export a function (potentially `async`) to resolve the configuration.  
We found it particularly useful when resolving DynamoDB setup from the Serverless Framework, so one does not have to repeat ones own Dynamo table setup in code.  
Could of course support other use cases as well.

```js
module.exports = async () => {
  await serverless.init();
  const service = await serverless.variables.populateService();
  const tables = service.resources.Resources.filter(r => r.Type === 'AWS::DynamoDB::Table').map(
    r => r.Properties
  );

  return {
    tables,
    port: 8000
  };
};
```