### PR TITLE
Use debug instead of console.log

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const NodeEnvironment = require('jest-environment-node');
+const debug = require('debug')('jest-dynamodb');
 
 module.exports = class DynamoDBEnvironment extends NodeEnvironment {
   constructor(config) {
@@ -7,13 +8,13 @@ module.exports = class DynamoDBEnvironment extends NodeEnvironment {
   }
 
   async setup() {
-    console.log('Setup DynamoDB Test Environment');
+    debug('Setup DynamoDB Test Environment');
 
     await super.setup();
   }
 
   async teardown() {
-    console.log('Teardown DynamoDB Test Environment');
+    debug('Teardown DynamoDB Test Environment');
 
     await super.teardown();
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "dependencies": {
     "cwd": "0.10.0",
+    "debug": "^4.1.1",
     "dynamodb-local": "0.0.29"
   },
   "peerDependencies": {

--- a/teardown.js
+++ b/teardown.js
@@ -1,7 +1,8 @@
 const DynamoDbLocal = require('dynamodb-local');
+const debug = require('debug')('jest-dynamodb');
 
 module.exports = async function() {
   // eslint-disable-next-line no-console
-  console.log('Teardown DynamoDB');
+  debug('Teardown DynamoDB');
   await DynamoDbLocal.stopChild(global.__DYNAMODB__);
 };


### PR DESCRIPTION
Messages coming from console.log can become distracting when running tests. The [visionmedia/debug](https://github.com/visionmedia/debug) library is commonly used to enable users to print debug statements when troubleshooting but also hide them during normal operation.