### PR TITLE
fix: Port does not work with promise config

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -2,31 +2,27 @@ const {resolve} = require('path');
 const cwd = require('cwd');
 const DynamoDB = require('aws-sdk/clients/dynamodb');
 const DynamoDbLocal = require('dynamodb-local');
-const config = require(resolve(cwd(), 'jest-dynamodb-config.js'));
-
-const DEFAULT_PORT = 8000;
-const port =
-  typeof config.port === 'undefined' || config.port === null ? DEFAULT_PORT : config.port;
 
 // aws-sdk requires access and secret key to be able to call DDB
 process.env.AWS_ACCESS_KEY_ID = 'access-key';
 process.env.AWS_SECRET_ACCESS_KEY = 'secret-key';
 
-const dynamoDB = new DynamoDB({
-  endpoint: 'localhost:' + port,
-  sslEnabled: false,
-  region: 'local-env'
-});
+const DEFAULT_PORT = 8000;
 
 module.exports = async function() {
+  const config = require(resolve(cwd(), 'jest-dynamodb-config.js'));
+  const {tables, port: port = DEFAULT_PORT} =
+    typeof config === 'function' ? await config() : config;
+  const dynamoDB = new DynamoDB({
+    endpoint: 'localhost:' + port,
+    sslEnabled: false,
+    region: 'local-env'
+  });
   global.__DYNAMODB__ = await DynamoDbLocal.launch(port, null, ['-sharedDb']);
 
-  await createTables();
+  await createTables(dynamoDB, tables);
 };
 
-async function createTables() {
-  const config = require(resolve(cwd(), 'jest-dynamodb-config.js'));
-  const {tables} = typeof config === 'function' ? await config() : config;
-
+async function createTables(dynamoDB, tables) {
   return Promise.all(tables.map(table => dynamoDB.createTable(table).promise()));
 }


### PR DESCRIPTION
The port used to be resolved assuming config is an object, while the change introduced in #24 allowed sending in a `config` Promise.  