### PR TITLE
chore(readme): added instructions for reading cloudformation templates directly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Or read table definitions from a CloudFormation template (example handles a !Sub
 
 const yaml = require('js-yaml');
 const fs   = require('fs');
-var CLOUDFORMATION_SCHEMA = require('cloudformation-js-yaml-schema').CLOUDFORMATION_SCHEMA;
+const {CLOUDFORMATION_SCHEMA} = require('cloudformation-js-yaml-schema');
 
 module.exports = async () => {
 


### PR DESCRIPTION
Adding instructions on using a Cloudformation template with Dynamo Table definitions directly. Because my sample uses TableName that includes a !Sub for each environment (prod, test, etc) I left this code in as well.