### PR TITLE
Mention java runtime as dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 $ yarn add @shelf/jest-dynamodb --dev
 ```
 
-Make sure `aws-sdk` is installed as a peer dependency.
+Make sure `aws-sdk` is installed as a peer dependency. And `java` runtime available for running [DynamoDBLocal.jar](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html)
 
 ### 1. Create `jest.config.js`
 


### PR DESCRIPTION
Issue caused by missing java runtime:
```
  Error: spawn java ENOENT
      at Process.ChildProcess._handle.onexit (internal/child_process.js:267:19)
      at onErrorNT (internal/child_process.js:469:16)
      at processTicksAndRejections (internal/process/task_queues.js:84:21)
```