### PR TITLE
Allow jest watch / watchAll

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -41,7 +41,9 @@ module.exports = async function () {
       DynamoDbLocal.configureInstaller(installerConfig);
     }
 
-    global.__DYNAMODB__ = await DynamoDbLocal.launch(port, null, options);
+    if(!global.__DYNAMODB__) {
+      global.__DYNAMODB__ = await DynamoDbLocal.launch(port, null, options);
+    }
   }
 
   await createTables(dynamoDB, newTables);

--- a/teardown.js
+++ b/teardown.js
@@ -1,12 +1,15 @@
 const DynamoDbLocal = require('dynamodb-local');
 const debug = require('debug')('jest-dynamodb');
 
-module.exports = async function () {
+module.exports = async function (jestArgs) {
   // eslint-disable-next-line no-console
   debug('Teardown DynamoDB');
 
   if (global.__DYNAMODB__) {
-    await DynamoDbLocal.stopChild(global.__DYNAMODB__);
+    const watching = jestArgs.watch || jestArgs.watchAll;
+    if (!watching) {
+      await DynamoDbLocal.stopChild(global.__DYNAMODB__);
+    }
   } else {
     const dynamoDB = global.__DYNAMODB_CLIENT__;
     const {TableNames: tableNames} = await dynamoDB.listTables().promise();


### PR DESCRIPTION
Uses an existence check at startup to avoid attempting to re-instantiate the dynamodb-local server if already defined. Also uses jest's [globalConfig argument at teardown](https://jestjs.io/docs/en/configuration#globalteardown-string) to detect watch state and avoid tearing down the server prematurely.