### PR TITLE
add wait-for-localhost.js to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "environment.js",
     "jest-preset.js",
     "setup.js",
-    "teardown.js"
+    "teardown.js",
+    "wait-for-localhost.js"
   ],
   "scripts": {
     "coverage": "jest --coverage",


### PR DESCRIPTION
When trying to use v 2.0.1, I receive the following error:
```Error: Jest: Got error running globalSetup - /Users/[...]/node_modules/@shelf/jest-dynamodb/setup.js, reason: Cannot find module './wait-for-localhost'```

To solve this problem, I included the file wait-for-localhost in the list of files in package.json.
Hope a new version will be published soon, so I can finally test my code for AWS V3 dynamo client ;) 