### PR TITLE
Support monorepos with nested jest projects by providing env to set jest-dynamodb-config.js path 

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -38,7 +38,7 @@ module.exports = async function () {
   try {
     const {TableNames: tableNames} = await Promise.race([
       dynamoDB.listTables({}),
-      waitForLocalhost(DEFAULT_PORT)
+      waitForLocalhost(port)
     ]);
     await deleteTables(dynamoDB, tableNames); // cleanup leftovers
   } catch (err) {
@@ -54,7 +54,7 @@ module.exports = async function () {
 
       global.__DYNAMODB__ = await DynamoDbLocal.launch(port, null, options);
 
-      await waitForLocalhost(DEFAULT_PORT);
+      await waitForLocalhost(port);
     }
   }
 

--- a/setup.js
+++ b/setup.js
@@ -13,7 +13,9 @@ const DEFAULT_PORT = 8000;
 const DEFAULT_OPTIONS = ['-sharedDb'];
 
 module.exports = async function () {
-  const config = require(resolve(cwd(), 'jest-dynamodb-config.js'));
+  const config = require(process.env.JEST_DYNAMODB_CONFIG ||
+    resolve(cwd(), 'jest-dynamodb-config.js'));
+  debug('config:', config);
   const {
     tables: newTables,
     clientConfig,
@@ -53,10 +55,12 @@ module.exports = async function () {
       debug('spinning up a local ddb instance');
 
       global.__DYNAMODB__ = await DynamoDbLocal.launch(port, null, options);
+      debug(`dynamodb-local started on port ${port}`);
 
       await waitForLocalhost(port);
     }
   }
+  debug(`dynamodb-local is ready on port ${port}`);
 
   await createTables(dynamoDB, newTables);
 };


### PR DESCRIPTION
## Summary
When using monorepos with nested "jest projects", the `setup.js` file in `jest-dynamodb` requires the `jest-dynamodb-config.js` file to me located with `cwd` directory.

This updates the setup file to check for `JEST_DYNAMODB_CONFIG` environment variable to use as config path, with fallback to `cwd` location as default.

### Additional
Not sure why the `port` value within setup file was using `DEFAULT_PORT` rather than `config.port` in several cases, this was breaking my tests. I have also updated to use the `config.port` value throughout with `DEFAULT_PORT` only applied as "default", which assuming is intention.

## Testing Done
This has been tested on a monorepo with nested jest projects and works as expected.
