### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,7 +154,11 @@ const {DocumentClient} = require('aws-sdk/clients/dynamodb');
 const isTest = process.env.JEST_WORKER_ID;
 const config = {
   convertEmptyValues: true,
-  ...(isTest && {endpoint: 'localhost:8000', sslEnabled: false, region: 'local-env'})
+  ...(isTest && {endpoint: 'localhost:8000', sslEnabled: false, region: 'local-env',
+    credentials: {
+      accessKeyId: 'fakeMyKeyId',
+      secretAccessKey: 'fakeSecretAccessKey'
+    }})
 };
 
 const ddb = new DocumentClient(config);


### PR DESCRIPTION
Add credentials to Configure DynamoDB client (from aws-sdk v2)
Otherwise, I had these errors after migrating from v1.7.0 to v2.2.3: 
thrown: "Exceeded timeout of 5000 ms for a test.
Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
Or
connect EHOSTDOWN 169.x.x.x:80 - Local (10.0.x.x:54383)