### PR TITLE
Fix logic for setup, use await vs promises

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -34,13 +34,11 @@ module.exports = async function () {
   global.__DYNAMODB_CLIENT__ = dynamoDB;
 
   try {
-    const promises = [dynamoDB.listTables({})];
-
     if (!global.__DYNAMODB__) {
-      promises.push(waitForLocalhost(port));
+      await waitForLocalhost(port);
     }
 
-    const {TableNames: tableNames} = await Promise.race(promises);
+    const {TableNames: tableNames} = await dynamoDB.listTables({});
     await deleteTables(dynamoDB, tableNames); // cleanup leftovers
   } catch (err) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
I ran into an issue where Promises.race() would return the promise from waitForLocalhost before listTables() then tableNames would be `undefined`, then throwing an err (undefined parameter) and thus attempting to spin up a local ddb instance (when I was already running one in docker).

This PR switches the logic to use await and ends up in a better flow overall.

Have tested locally and is working fine now.