### PR TITLE
Update .circleci config for Node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   test_without_db:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
 
     steps:
       - checkout
@@ -14,7 +14,7 @@ jobs:
   test_with_db:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
       - image: circleci/dynamodb:oracle
 
     steps:


### PR DESCRIPTION
This package requires Node 14, as per https://github.com/shelfio/jest-dynamodb/blob/master/package.json#L70

Currently we're using Node 12 on the CircleCI runners, causing CI to fail. This PR updates the image used by the CircleCI runners so the CI passes.