### PR TITLE
update teardown to only delete newly created test tables

### DIFF
--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -1,5 +1,8 @@
 import DynamoDbLocal from 'dynamodb-local';
 import type {JestArgs} from './types';
+import deleteTables from './utils/delete-tables';
+import getConfig from './utils/get-config';
+import getRelevantTables from './utils/get-relevant-tables';
 
 const debug = require('debug')('jest-dynamodb');
 
@@ -15,10 +18,12 @@ export default async function (jestArgs: JestArgs) {
     }
   } else {
     const dynamoDB = global.__DYNAMODB_CLIENT__;
+    const {tables: targetTables} = await getConfig(debug);
+
     const {TableNames: tableNames} = await dynamoDB.listTables({});
 
     if (tableNames?.length) {
-      await Promise.all(tableNames.map(tableName => dynamoDB.deleteTable({TableName: tableName})));
+      await deleteTables(dynamoDB, getRelevantTables(tableNames, targetTables));
     }
   }
-};
+}

--- a/src/utils/delete-tables.ts
+++ b/src/utils/delete-tables.ts
@@ -1,0 +1,5 @@
+import type {DynamoDB} from '@aws-sdk/client-dynamodb';
+
+export default function deleteTables(dynamoDB: DynamoDB, tableNames: string[]) {
+  return Promise.all(tableNames.map(tableName => dynamoDB.deleteTable({TableName: tableName})));
+}

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -1,0 +1,11 @@
+import {resolve} from 'path';
+import cwd from 'cwd';
+import type {Config} from '../types';
+
+export default async function getConfig(debug: any): Promise<Config> {
+  const path = process.env.JEST_DYNAMODB_CONFIG || resolve(cwd(), 'jest-dynamodb-config.js');
+  const config = require(path);
+  debug('config:', config);
+
+  return typeof config === 'function' ? await config() : config;
+}

--- a/src/utils/get-relevant-tables.ts
+++ b/src/utils/get-relevant-tables.ts
@@ -1,0 +1,10 @@
+import type {CreateTableCommandInput} from '@aws-sdk/client-dynamodb';
+
+export default function getRelevantTables(
+  dbTables: string[],
+  configTables: CreateTableCommandInput[]
+) {
+  const configTableNames = configTables.map(configTable => configTable.TableName);
+
+  return dbTables.filter(dbTable => configTableNames.includes(dbTable));
+}


### PR DESCRIPTION
#95 highlights a problem with using this library. If you are using the `sharedDb` flag on a dynamodb-local instance, it clears the entire database as part of teardown. In my case, I was using stages to separate database tables by environment but the teardown here is indiscriminate and deletes everything. As a developer writing tests, I only want this tool to delete the tables it creates and leave other deletion to the implementor to decide as described in the discussion of #55. This PR makes the following changes:

- update setup and teardown to only attempt deletion of tables created by setup
- refactor getConfig and deleteTables to new utils
- add getRelevantTables util
- refactor setup to use new utils

Closes https://github.com/shelfio/jest-dynamodb/issues/95