### PR TITLE
FIX: aws-sdk v3 expects the endpoint to contain the protocol

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,8 +190,7 @@ const isTest = process.env.JEST_WORKER_ID;
 const ddb = DynamoDBDocument.from(
   new DynamoDB({
     ...(isTest && {
-      endpoint: 'localhost:8000',
-      sslEnabled: false,
+      endpoint: 'http://localhost:8000',
       region: 'local-env',
       credentials: {
         accessKeyId: 'fakeMyKeyId',


### PR DESCRIPTION
Without this users will get the following error when running tests

`AWS SDK error wrapper for Error: connect EHOSTUNREACH 0.0.31.64:80 - Local (192.168.1.19:57502)`

It's quite hard to debug and I was stuck on it for a while