### PR TITLE
Fix "Jest did not exit one second after the test run has completed" warning

### DIFF
--- a/src/utils/wait-for-localhost.ts
+++ b/src/utils/wait-for-localhost.ts
@@ -11,7 +11,7 @@ export default function waitForLocalhost(port: number, host: string): Promise<vo
     const retry = () => setTimeout(main, 200);
     const main = () => {
       const request = http.request(
-        {method: 'GET', port, host, path: '/'},
+        {method: 'GET', port, host, path: '/', headers: {Connection: 'close'}},
         (response: {statusCode: number}) => {
           if (response.statusCode === 400) {
             return resolve();


### PR DESCRIPTION
The request used to determine when localhost is ready is remaining open for 30 seconds, causing Jest to continue running unnecessarily when test suites complete within that time.

Fixes issues:
https://github.com/shelfio/jest-dynamodb/issues/223
https://github.com/shelfio/jest-dynamodb/issues/127